### PR TITLE
Add mLLMCelltype to Transcriptomics tools

### DIFF
--- a/TRANSCRIPTOMICS.md
+++ b/TRANSCRIPTOMICS.md
@@ -11,5 +11,6 @@ General Resources for Transcriptomics
 
 ## Tools
 - [cellxgene](https://github.com/chanzuckerberg/cellxgene) - An interactive explorer for single-cell transcriptomics data
+- [mLLMCelltype](https://github.com/cafferychen777/mLLMCelltype) - An iterative multi-LLM consensus framework for cell type annotation in single-cell RNA sequencing data
 ## Pipelines
 - [starfish](https://github.com/spacetx/starfish) - unified pipelines for image-based transcriptomics


### PR DESCRIPTION
Add mLLMCelltype to the Transcriptomics tools list. mLLMCelltype is an iterative multi-LLM consensus framework for cell type annotation in single-cell RNA sequencing data. This tool significantly improves annotation accuracy by leveraging the complementary strengths of multiple large language models, while providing transparent uncertainty quantification.