### PR TITLE
Add FlashDeconv to Transcriptomics Pipelines

### DIFF
--- a/TRANSCRIPTOMICS.md
+++ b/TRANSCRIPTOMICS.md
@@ -12,4 +12,5 @@ General Resources for Transcriptomics
 ## Tools
 - [cellxgene](https://github.com/chanzuckerberg/cellxgene) - An interactive explorer for single-cell transcriptomics data
 ## Pipelines
+- [FlashDeconv](https://github.com/cafferychen777/flashdeconv) - High-performance spatial transcriptomics deconvolution for cell type mapping
 - [starfish](https://github.com/spacetx/starfish) - unified pipelines for image-based transcriptomics


### PR DESCRIPTION
This PR adds FlashDeconv to the Transcriptomics Pipelines section.

**FlashDeconv** is a high-performance spatial transcriptomics deconvolution tool for cell type mapping. It uses structure-preserving randomized sketching for efficient processing of large-scale spatial datasets.

- GitHub: https://github.com/cafferychen777/flashdeconv
- Paper: https://doi.org/10.64898/2025.12.22.696108